### PR TITLE
Fix usage of spdlog and fmt libs and headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ LIBRARY_PATH := $(abspath ./)
 
 BUILD_TYPE?=
 # keep standard at C11 and C++11
-CFLAGS   = -I. -I./piper/src/cpp -I./piper/build/pi/include -O3 -DNDEBUG -std=c11 -fPIC
-CXXFLAGS = -I. -I./piper/src/cpp -I./piper/build/pi/include -O3 -DNDEBUG -std=c++17 -fPIC
-LDFLAGS  = -L./piper/build/pi/lib -lfmt -lspdlog
+CFLAGS   = -I. -I./piper/src/cpp -I./piper/build/fi/include -I./piper/build/pi/include -I./piper/build/si/include -O3 -DNDEBUG -std=c11 -fPIC
+CXXFLAGS = -I. -I./piper/src/cpp -I./piper/build/fi/include -I./piper/build/pi/include -I./piper/build/si/include -O3 -DNDEBUG -std=c++17 -fPIC
+LDFLAGS  = -L./piper/build/fi/lib -L./piper/build/pi/lib -L./piper/build/si/lib -lfmt -lspdlog
 
 # warnings
 CFLAGS   += -Wall -Wextra -Wpedantic -Wcast-qual -Wdouble-promotion -Wshadow -Wstrict-prototypes -Wpointer-arith -Wno-unused-function


### PR DESCRIPTION
This should fixes once and for all issues in LocalAI pipeline.
previous failure was caused by shared libfmt and spdlog libraries installed on my system.

also checking with 
`ldd backend-assets/grpc/piper`
gives no libfmt or spdlog references as it should be.
