### PR TITLE
feat: add TextToWavSpeaker

### DIFF
--- a/gopiper.cpp
+++ b/gopiper.cpp
@@ -26,10 +26,9 @@
 
 using namespace std;
 
-int piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, char *dst) {
+int _piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, char *dst, optional<piper::SpeakerId> speakerId) {
   filesystem::path model_path;
   filesystem::path config_path;
-  optional<piper::SpeakerId> speakerId;
   model_path = filesystem::path(std::string(model));
   config_path = filesystem::path(std::string(model) + ".json");
 
@@ -82,3 +81,11 @@ int piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, cha
   return EXIT_SUCCESS;
 }
 
+int piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, char *dst) {
+  optional<piper::SpeakerId> speakerId;
+  return _piper_tts(text, model, espeakData, tashkeelPath, dst, speakerId);
+}
+
+int piper_tts_speaker(char *text, char *model, char *espeakData, char *tashkeelPath, char *dst, int64_t speakerId) {
+  return _piper_tts(text, model, espeakData, tashkeelPath, dst, speakerId);
+}

--- a/gopiper.h
+++ b/gopiper.h
@@ -2,6 +2,7 @@
 extern "C" {
 #endif
 int piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, char *dst);
+int piper_tts_speaker(char *text, char *model, char *espeakData, char *tashkeelPath, char *dst, int64_t speakerId);
 #ifdef __cplusplus
 }
 #endif

--- a/piper.go
+++ b/piper.go
@@ -22,3 +22,18 @@ func TextToWav(text, model, espeek, tas, dst string) error {
 	}
 	return nil
 }
+
+func TextToWavSpeaker(text, model, espeek, tas, dst string, speakerId int64) error {
+	t := C.CString(text)
+	m := C.CString(model)
+	ee := C.CString(espeek)
+	tt := C.CString(tas)
+	d := C.CString(dst)
+	sid := C.int64_t(speakerId)
+
+	ret := C.piper_tts_speaker(t, m, ee, tt, d, sid)
+	if ret != 0 {
+		return fmt.Errorf("failed")
+	}
+	return nil
+}


### PR DESCRIPTION
## Description
This commit adds `TextToWavSpeaker` Go function and `piper_tts_speaker` C function to be able to specify `speakerId` to Piper TTS.

When using Piper in french I came across a voice pack with two speakers and did not found a way to change the speaker id.


The implementation is not so beautiful but I think it will do the job.