### PR TITLE
feat: early exit if model or config file is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.onnx
 *.json
 *.tar.gz
+example/main

--- a/gopiper.cpp
+++ b/gopiper.cpp
@@ -32,6 +32,16 @@ int _piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, ch
   model_path = filesystem::path(std::string(model));
   config_path = filesystem::path(std::string(model) + ".json");
 
+  if (!filesystem::exists(model_path)) {
+    spdlog::debug("Error: Model path does not exist: ({})", model_path);
+    return EXIT_FAILURE;
+  }
+
+  if (!filesystem::exists(config_path)) {
+    spdlog::debug("Error: Config path does not exist: ({})", config_path);
+    return EXIT_FAILURE;
+  }
+
   piper::PiperConfig piperConfig;
   piper::Voice voice;
 

--- a/gopiper.cpp
+++ b/gopiper.cpp
@@ -33,12 +33,12 @@ int _piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, ch
   config_path = filesystem::path(std::string(model) + ".json");
 
   if (!filesystem::exists(model_path)) {
-    spdlog::debug("Error: Model path does not exist: ({})", model_path);
+    spdlog::debug("Error: Model path does not exist: ({})", model_path.c_str());
     return EXIT_FAILURE;
   }
 
   if (!filesystem::exists(config_path)) {
-    spdlog::debug("Error: Config path does not exist: ({})", config_path);
+    spdlog::debug("Error: Config path does not exist: ({})", config_path.c_str());
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
exit early if either the model or config file are not found. Should make CI errors less opaque, as we now log which file has failed.