### PR TITLE
Revert "feat: early exit if model or config file is missing"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.onnx
 *.json
 *.tar.gz
-example/main

--- a/gopiper.cpp
+++ b/gopiper.cpp
@@ -32,16 +32,6 @@ int _piper_tts(char *text, char *model, char *espeakData, char *tashkeelPath, ch
   model_path = filesystem::path(std::string(model));
   config_path = filesystem::path(std::string(model) + ".json");
 
-  if (!filesystem::exists(model_path)) {
-    spdlog::debug("Error: Model path does not exist: ({})", model_path.c_str());
-    return EXIT_FAILURE;
-  }
-
-  if (!filesystem::exists(config_path)) {
-    spdlog::debug("Error: Config path does not exist: ({})", config_path.c_str());
-    return EXIT_FAILURE;
-  }
-
   piper::PiperConfig piperConfig;
   piper::Voice voice;
 


### PR DESCRIPTION
Reverts mudler/go-piper#8

See failures in : https://github.com/mudler/LocalAI/pull/3949

(@dave-gray101 I'm reverting until we fix that on master so we do not choke on CI and we have a clean master, to pick this up again it's just about reverting the reverts :) )